### PR TITLE
Flush buffers after each log entry.

### DIFF
--- a/src/import-main.hs
+++ b/src/import-main.hs
@@ -95,10 +95,10 @@ parseConduit DFJSON =
             Right x -> pure x
 
 binaryConduit :: ListOfStringable a =>
-    Conduit (TimeLogEntry a, Maybe a) IO BS.ByteString
-binaryConduit = C.map go
+    Conduit (TimeLogEntry a, Maybe a) IO (Flush BS.ByteString)
+binaryConduit = C.concatMap go
   where
-    go (x,prev) = BSL.toStrict $ ls_encode strs x
+    go (x,prev) = [Chunk $ BSL.toStrict $ ls_encode strs x, Flush]
         where strs = maybe [] listOfStrings prev
 
 main = do
@@ -127,7 +127,7 @@ main = do
     =$= parseConduit (optFormat flags)
     =$= stutter
     =$= binaryConduit
-    =$= C.sinkHandle h
+    =$= C.sinkHandleFlush h
   hClose h
 
 


### PR DESCRIPTION
Ensures that log entries are promptly written to the log file when used
interactively. Additionally, in the case of application / system crash,
log file is more likely to remain in consistent state.

As far as I can see, this approach has one drawback. In case of batch
processing (rather than more interactive use), it introduces additional write
syscalls and potentially reduces performance, but I think this is right
trade-off to make.

It also buffers up to one log entry, due to parsing with `json <* skipSpace`,
i.e., parser won't yield JSON values until it consumes all following whitespace.
This could be addressed later.