### PR TITLE
Add GNOME Shell extension to docs, show --version and --help on stdout, ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+doc/arbtt.pdf
+doc/man/
+doc/users_guide/

--- a/doc/arbtt.xml
+++ b/doc/arbtt.xml
@@ -1107,8 +1107,8 @@ arbtt &lt;- reshape(arbtt, v.names=&quot;Time&quot;, timevar=&quot;Tag&quot;, id
     linkend="arbtt-dump"/>.</para>
 
     <para>The textual form can be imported back using
-    <command>arbtt-stats</command>. Its command line reference is given in
-    <xref linkend="arbtt-dump"/>.</para>
+    <command>arbtt-import</command>. Its command line reference is given in
+    <xref linkend="arbtt-import"/>.</para>
 
     <para>If <command>arbtt-capture</command> crashes it might be that the log
     file is not readable any more. In some cases, this can be fixed using the
@@ -1570,7 +1570,7 @@ arbtt-stats -f '$sampleage &lt; 1:00'</screen>
     </refsect1>
   </refentry>
 
-  <refentry>
+  <refentry id="arbtt-import">
     <refnamediv>
       <refname>arbtt-import</refname>
       <refpurpose>imports dumped arbtt data samples</refpurpose>

--- a/doc/arbtt.xml
+++ b/doc/arbtt.xml
@@ -1045,11 +1045,11 @@ arbtt &lt;- reshape(arbtt, v.names=&quot;Time&quot;, timevar=&quot;Tag&quot;, id
 <sect1 id="contributed">
   <title>Contributed tools</title>
   <para>
-    Due to the export facilities of arbtt (as explained in <xref
-    linkend="external-processing"/>), tools analyzing arbtt’s data can be
-    developed independently. This section lists those that we are aware of. If
-    you create a tool of your own, or find one somewhere, please tell us on the
-    mailing list (see <xref linkend="copyright"/>).
+    Due to the import and export facilities of arbtt (as explained in <xref
+    linkend="external-processing"/>), tools producing and analyzing arbtt’s
+    data can be developed independently. This section lists those that we are
+    aware of. If you create a tool of your own, or find one somewhere, please
+    tell us on the mailing list (see <xref linkend="copyright"/>).
   </para>
   <sect2>
     <title>arbtt-graph</title>
@@ -1059,6 +1059,15 @@ arbtt &lt;- reshape(arbtt, v.names=&quot;Time&quot;, timevar=&quot;Tag&quot;, id
     </para>
     <para>
       You can find his tool on <ulink url="https://github.com/rejuvyesh/arbtt-graph">https://github.com/rejuvyesh/arbtt-graph</ulink>.
+    </para>
+  </sect2>
+  <sect2>
+    <title>arbtt-capture for GNOME Shell</title>
+    <para>
+      An arbtt-capture implemented as a GNOME Shell extension. Its main value
+      proposition is compatibility with Wayland (but it is compatible with
+      traditional X Window System as well). You can find it on
+      <ulink url="https://github.com/tmiasko/arbtt-capture">https://github.com/tmiasko/arbtt-capture</ulink>.
     </para>
   </sect2>
 </sect1>

--- a/src/Capture/X11.hs
+++ b/src/Capture/X11.hs
@@ -78,12 +78,18 @@ getWindowTitle dpy =  myFetchName dpy
 getProgramName :: Display -> Window -> IO String
 getProgramName dpy = fmap resName . getClassHint dpy
 
+-- Returns a parent of a window or zero.
+getParent :: Display -> Window -> IO Window
+getParent dpy w = do
+  (_, parent, _) <- queryTree dpy w `catchIOError` (const $ return (0,0,[]))
+  return parent
+
 -- | Follows the tree of windows up until the condition is met or the root
 -- window is reached.
 followTreeUntil :: Display -> (Window -> Bool) -> Window -> IO Window 
 followTreeUntil dpy cond = go
   where go w | cond w    = return w
-             | otherwise = do (r,p,_) <- queryTree dpy w
+             | otherwise = do p <- getParent dpy w
                               if p == 0 then return w
                                         else go p 
 

--- a/src/capture-main.hs
+++ b/src/capture-main.hs
@@ -44,13 +44,13 @@ options :: [OptDescr (Options -> IO Options)]
 options =
      [ Option "h?"     ["help"]
               (NoArg $ \_ -> do
-                    hPutStr stderr (usageInfo header options)
+                    putStr (usageInfo header options)
                     exitSuccess
               )
               "show this help"
      , Option "V"      ["version"]
               (NoArg $ \_ -> do
-                    hPutStrLn stderr versionStr
+                    putStrLn versionStr
                     exitSuccess
               )
               "show the version number"

--- a/src/dump-main.hs
+++ b/src/dump-main.hs
@@ -40,13 +40,13 @@ options :: [OptDescr (Options -> IO Options)]
 options =
      [ Option "h?"     ["help"]
               (NoArg $ \_ -> do
-                    hPutStr stderr (usageInfo header options)
+                    putStr (usageInfo header options)
                     exitSuccess
               )
               "show this help"
      , Option "V"      ["version"]
               (NoArg $ \_ -> do
-                    hPutStrLn stderr versionStr
+                    putStrLn versionStr
                     exitSuccess
               )
               "show the version number"

--- a/src/import-main.hs
+++ b/src/import-main.hs
@@ -50,13 +50,13 @@ options :: [OptDescr (Options -> IO Options)]
 options =
      [ Option "h?"     ["help"]
               (NoArg $ \_ -> do
-                    hPutStr stderr (usageInfo header options)
+                    putStr (usageInfo header options)
                     exitSuccess
               )
               "show this help"
      , Option "V"      ["version"]
               (NoArg $ \_ -> do
-                    hPutStrLn stderr versionStr
+                    putStrLn versionStr
                     exitSuccess
               )
               "show the version number"

--- a/src/recover-main.hs
+++ b/src/recover-main.hs
@@ -34,13 +34,13 @@ options :: [OptDescr (Options -> IO Options)]
 options =
      [ Option "h?"     ["help"]
               (NoArg $ \_ -> do
-                    hPutStr stderr (usageInfo header options)
+                    putStr (usageInfo header options)
                     exitSuccess
               )
               "show this help"
      , Option "V"      ["version"]
               (NoArg $ \_ -> do
-                    hPutStrLn stderr versionStr
+                    putStrLn versionStr
                     exitSuccess
               )
               "show the version number"

--- a/src/stats-main.hs
+++ b/src/stats-main.hs
@@ -57,13 +57,13 @@ options :: [OptDescr (Options -> IO Options)]
 options =
      [ Option "h?"      ["help"]
               (NoArg $ \_ -> do
-                    hPutStr stderr (usageInfo header options)
+                    putStr (usageInfo header options)
                     exitSuccess
               )
               "show this help"
      , Option "V"       ["version"]
               (NoArg $ \_ -> do
-                    hPutStrLn stderr versionStr
+                    putStrLn versionStr
                     exitSuccess
               )
               "show the version number"


### PR DESCRIPTION
Collection of small, but independent commits (I didn't want to create a
separate PR for each of them). In case you don't want all of them, they should
be easy to cherry-pick without any conflicts.

 * Include arbtt-capture for GNOME Shell in user guide.
 * Fix arbtt-import description.
 * Add documentation build outputs to .gitignore.
 * Show --version and --help output on stdout.
    
   For example, following works without having to redirect stderr as well:
    
       arbtt-stats --help | less
    
   This commit doesn't change behaviour of showing usage on stderr in case
   of an argument parsing error.

 * Catch exceptions from queryTree.
    
   This is in anticipation of fix in X11 package: https://github.com/xmonad/X11/pull/57