### PR TITLE
Be more honest about our Graphics.X11.XScreenSaver dependency

### DIFF
--- a/src/Capture/X11.hs
+++ b/src/Capture/X11.hs
@@ -13,12 +13,10 @@ import System.IO
 import qualified Data.MyText as T
 
 import System.Locale.SetLocale
-import Graphics.X11.XScreenSaver (getXIdleTime, compiledWithXScreenSaver)
+import Graphics.X11.XScreenSaver (getXIdleTime)
 
 setupCapture :: IO ()
 setupCapture = do
-        unless compiledWithXScreenSaver $
-                hPutStrLn stderr "arbtt [Warning]: X11 was compiled without support for XScreenSaver"
         loc <- supportsLocale
         unless loc $ hPutStrLn stderr "arbtt [Warning]: locale unsupported"
         dpy <- openDisplay ""


### PR DESCRIPTION
At the moment, there is a runtime check whether the X11 package (which provides Graphics.X11.XScreenSaver) was compiled with the libXScrnSaver system library. If not, the code emits a warning and tries to go on.

However, the code still references the `getXIdleTime` function of the `Graphics.X11.XScreenSaver` module. That module exports `getXIdleTime` only if it has been compiled with the libXScrnSaver library.

Thus at the moment, arbtt fails to compile if the X11 package was compiled without libXScrnSaver. (This is currently the default in NixOS, which is how I noticed this problem.)

This pull request simply removes the attempt to go on if libXScrnSaver is missing, since I deemed the idle time information to be too important. A perhaps better solution would be to upgrade `src/Capture/X11.hs` into an `hsc` file and only import `getXIdleTime` if the C preprocessor flag `HAVE_X11_EXTENSIONS_SCRNSAVER_H` is true, therefore feel exceptionally free to reject this pull request.

If we go with the approach of this pull request, then we should also record somewhere that we require that the X11 package was compiled with libXScrnSaver. Ideally we would specify this in the Cabal file, but I don't think we can. Else it should at least be mentioned in the README. Please direct me to the correct place. :-)

This pull request was joint work with @xaverdh.