### PR TITLE
Allow dots and slashes in tags

### DIFF
--- a/src/Categorize.hs
+++ b/src/Categorize.hs
@@ -482,9 +482,10 @@ parseSetTag = lexeme lang $ do
 replaceForbidden :: Maybe Text -> Maybe Text
 replaceForbidden = fmap $ T.map go
   where
-    go c | isAlphaNum c  = c
-         | c `elem` "-_" = c
-         | otherwise     = '_'
+    go c | isAlphaNum c    = c
+         | c `elem` "-_./" = c
+         | c == '\\'       = '/'
+         | otherwise       = '_'
 
 parseTagPart :: Parser (Ctx -> Maybe Text)
 parseTagPart = do parts <- many1 (choice


### PR DESCRIPTION
Hi! First off, thanks for the fantastic work here @nomeata. 😊 

I stumbled upon arbtt earlier today and started working on an initial configuration. One thing I tried was creating tags for particular websites. Capturing this works great with a [Chrome addon](https://chrome.google.com/webstore/detail/url-in-title/ignpacbgnbnkaiooknalneoeladjnfgb), but the output of `arbtt-stats` isn't as beautiful as it maybe could be:
```
$ arbtt-stats -c "web"
Statistics for category "web"
=============================
_________________Tag______|______Time_|_Percentage_
web:arbtt_nomeata_de_doc_ |     7m00s |      10.14
         (unmatched time) |  1h02m00s |      89.86
```

I feel that it would be much nicer to have this:

```
$ arbtt-stats -c "web"
Statistics for category "web"
=============================
_________________Tag______|______Time_|_Percentage_
web:arbtt.nomeata.de/doc/ |     7m00s |      10.14
         (unmatched time) |  1h02m00s |      89.86
```

The same issue occurs for folders, where `/` and `\` are replaced with underscores as well (`Program_Files__x86__Google_Chrome_Application_chrome_exe`). 

This PR makes `replaceForbidden` a bit more lax by allowing `.`, `/`, and `\`. As `\` is a bit problematic as an escape character, I decided to replace it with a forward slash. While maybe not ideal, it makes Windows paths much nicer. Maybe it's also nice to allow parantheses, but I wanted to keep it minimal for now and only include the characters I would care about.

Thanks!
Max