### PR TITLE
Version churn

### DIFF
--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -107,7 +107,7 @@ executable arbtt-stats
         transformers, directory, filepath,
         aeson >= 0.10  && < 1.3,
         array == 0.4.* || == 0.5.*,
-        terminal-progress-bar < 0.2,
+        terminal-progress-bar >= 0.2 && < 0.3,
         bytestring-progress,
         mtl
 

--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -187,7 +187,7 @@ executable arbtt-import
         containers == 0.5.*,
         binary >= 0.5,
         aeson >= 0.10  && < 1.3,
-        conduit == 1.2.*,
+        conduit >= 1.2 && < 1.4,
         exceptions == 0.8.*,
         attoparsec == 0.13.*,
         deepseq, bytestring, utf8-string, strict,

--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -281,7 +281,7 @@ test-suite test
     TimeLog
   Build-depends:
       base >= 4.7 && < 4.11
-      , tasty >= 0.7 && < 0.13
+      , tasty >= 0.7 && < 1.1
       , tasty-golden >= 2.2.0.2  && < 2.4
       , tasty-hunit >= 0.2  && < 0.11
       , process-extras >= 0.2 && < 0.8

--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -227,7 +227,9 @@ executable arbtt-import
         Data.Conduit.Binary
         Data.Streaming.FileRead
     build-depends:
-        text, resourcet, unliftio-core
+        text,
+        resourcet >= 1.2,
+        unliftio-core
 
 executable arbtt-recover
     main-is:            recover-main.hs

--- a/src/Data/Conduit/Attoparsec.hs
+++ b/src/Data/Conduit/Attoparsec.hs
@@ -38,7 +38,7 @@ import qualified Data.Attoparsec.ByteString
 import qualified Data.Attoparsec.Text
 import qualified Data.Attoparsec.Types      as A
 import           Data.Conduit
-import Control.Monad.Trans.Resource (MonadThrow, monadThrow)
+import Control.Monad.Trans.Resource (MonadThrow, throwM)
 
 -- | The context and message from a 'A.Fail' value.
 data ParseError = ParseError
@@ -114,7 +114,7 @@ instance AttoparsecInput T.Text where
 -- | Convert an Attoparsec 'A.Parser' into a 'Sink'. The parser will
 -- be streamed bytes until it returns 'A.Done' or 'A.Fail'.
 --
--- If parsing fails, a 'ParseError' will be thrown with 'monadThrow'.
+-- If parsing fails, a 'ParseError' will be thrown with 'throwM'.
 --
 -- Since 0.5.0
 sinkParser :: (AttoparsecInput a, MonadThrow m) => A.Parser a b -> Consumer a m b
@@ -193,7 +193,7 @@ sinkParserPosErr
     -> Consumer a m (Position, b)
 sinkParserPosErr pos0 p = sinkParserPos pos0 p >>= f
     where
-      f (Left e) = monadThrow e
+      f (Left e) = throwM e
       f (Right a) = return a
 {-# INLINE sinkParserPosErr #-}
 

--- a/src/stats-main.hs
+++ b/src/stats-main.hs
@@ -189,7 +189,8 @@ main = do
         (_height, width) <- getTermSize
         hPutChar stderr '\r'
         hPutStr stderr $
-            mkProgressBar (msg "Processing data") percentage (fromIntegral width) (fromIntegral b) (fromIntegral size)
+            mkProgressBar (msg "Processing data") percentage (fromIntegral width) $
+                Progress (fromIntegral b) (fromIntegral size)
         when  (fromIntegral b >= fromIntegral size) $ do
             hPutChar stderr '\r'
             hPutStr stderr (replicate width ' ')


### PR DESCRIPTION
My favourite time tracker no longer compiles on NixOS unstable which tracks the latest versions of packages from Hackage.

Here are a few fixes to make it build again.

I am running the updated version now and it seems to work.
