### PR TITLE
Fix require X11 1.9 and bump base upper bound to < 5.

### DIFF
--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -40,7 +40,7 @@ executable arbtt-capture
     main-is:            capture-main.hs
     hs-source-dirs:     src
     build-depends:
-                base >= 4.7 && < 4.11,
+                base >= 4.7 && < 5,
                 filepath, directory, transformers, utf8-string, strict, containers,
                 aeson >= 0.10  && < 1.3,
                 binary >= 0.5,
@@ -98,7 +98,7 @@ executable arbtt-stats
     main-is:            stats-main.hs
     hs-source-dirs:     src
     build-depends:
-        base >= 4.7 && < 4.11,
+        base >= 4.7 && < 5,
         parsec == 3.*,
         containers == 0.5.*,
         pcre-light,
@@ -145,7 +145,7 @@ executable arbtt-dump
     main-is:            dump-main.hs
     hs-source-dirs:     src
     build-depends:
-        base >= 4.7 && < 4.11,
+        base >= 4.7 && < 5,
         parsec == 3.*,
         containers == 0.5.*,
         aeson >= 0.10  && < 1.3,
@@ -182,7 +182,7 @@ executable arbtt-import
     main-is:            import-main.hs
     hs-source-dirs:     src
     build-depends:
-        base >= 4.7 && < 4.11,
+        base >= 4.7 && < 5,
         parsec == 3.*,
         containers == 0.5.*,
         binary >= 0.5,
@@ -235,7 +235,7 @@ executable arbtt-recover
     main-is:            recover-main.hs
     hs-source-dirs:     src
     build-depends:
-        base >= 4.7 && < 4.11,
+        base >= 4.7 && < 5,
         containers == 0.5.*,
         binary >= 0.5,
         deepseq, bytestring, utf8-string,
@@ -280,7 +280,7 @@ test-suite test
     Text.Regex.PCRE.Light.Text
     TimeLog
   Build-depends:
-      base >= 4.7 && < 4.11
+      base >= 4.7 && < 5
       , tasty >= 0.7 && < 1.1
       , tasty-golden >= 2.2.0.2  && < 2.4
       , tasty-hunit >= 0.2  && < 0.11

--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -91,7 +91,7 @@ executable arbtt-capture
                 Capture.X11
                 System.Locale.SetLocale
             build-depends:
-                X11 > 1.9
+                X11 >= 1.9
     default-language: Haskell98
 
 executable arbtt-stats


### PR DESCRIPTION
* Change bound on X11 to >= 1.9
* Change upper bound on base to < 5.

I am using stack to resolve the dependencies, and with those changes I need one
extra dependency on yet unreleased bytestring-progress 1.2, to successfully build
arbtt.