### PR TITLE
macOS install: Fix path to launchd folder and improve instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ session:
   </plist>
   ```
   and place it in `~/Library/LaunchAgents/com.foo.arbtt.plist`.
-  (You can replace "foo" with anything, such as your username)
+  You can replace "foo" with anything, such as your username, in both file name and content.
   This will ensure `arbtt-capture` is started whenever you log in.
 
 If you want to record samples at a different rate than one per minute, you

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ session:
   and place it in `~/Library/LaunchAgents/com.foo.arbtt.plist`.
   You can replace "foo" with anything, such as your username, in both file name and content.
   This will ensure `arbtt-capture` is started whenever you log in.
+  To start the service without needing a new login, you can run `launchctl load ~/Library/LaunchAgents/com.foo.arbtt.plist`.
 
 If you want to record samples at a different rate than one per minute, you
 will have to pass the `--sample-rate` parameter to arbtt-capture.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ session:
       </dict>
   </plist>
   ```
-  and place it in `~/LaunchAgents/com.foo.arbtt.plist`.
+  and place it in `~/Library/LaunchAgents/com.foo.arbtt.plist`.
   (You can replace "foo" with anything, such as your username)
   This will ensure `arbtt-capture` is started whenever you log in.
 


### PR DESCRIPTION
A few improvements I needed to actually get `arbtt-capture` started.