### PR TITLE
Fix tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,14 @@ script:
  - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal new-build
  - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal new-test
  - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal check
- - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal new-sdist
+ - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal sdist
  - test -z "$STACK" || stack build --test
 
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
  - test -z "$CABALVER" -a -z "$WINDOWS" || {
    export SRC_TGZ=$($W cabal info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist-newstyle/sdist/;
+   cd dist/;
    if [ -f "$SRC_TGZ" ]; then
       $W cabal install --force-reinstalls "$SRC_TGZ";
    else

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,18 +41,18 @@ install:
  - test -z "$STACK" || stack build --only-dependencies
 
 script:
- - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal configure --enable-tests --enable-benchmarks -v2
- - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal build
- - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal test
+ - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal new-configure --enable-tests --enable-benchmarks -v2
+ - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal new-build
+ - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal new-test
  - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal check
- - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal sdist
+ - test -z "$CABALVER" -a -z "$WINDOWS" || $W cabal new-sdist
  - test -z "$STACK" || stack build --test
 
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
  - test -z "$CABALVER" -a -z "$WINDOWS" || {
    export SRC_TGZ=$($W cabal info . | awk '{print $2 ".tar.gz";exit}') ;
-   cd dist/;
+   cd dist-newstyle/sdist/;
    if [ -f "$SRC_TGZ" ]; then
       $W cabal install --force-reinstalls "$SRC_TGZ";
    else

--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -134,6 +134,7 @@ executable arbtt-stats
         Text.ParserCombinators.Parsec.ExprFail
         Text.Regex.PCRE.Light.Text
         TermSize
+        Paths_arbtt
     ghc-options: -rtsopts
     if os(windows)
         cpp-options:    -DWIN32
@@ -171,6 +172,7 @@ executable arbtt-dump
         TimeLog
         DumpFormat
         Data.List.TakeR
+        Paths_arbtt
     ghc-options: -rtsopts
     if os(windows)
         cpp-options:    -DWIN32
@@ -210,6 +212,7 @@ executable arbtt-import
         TimeLog
         LockFile
         DumpFormat
+        Paths_arbtt
     ghc-options: -rtsopts
     if os(windows)
         cpp-options:    -DWIN32
@@ -256,6 +259,7 @@ executable arbtt-recover
         Data.Binary.StringRef
         CommonStartup
         TimeLog
+        Paths_arbtt
     ghc-options: -rtsopts
     if os(windows)
         cpp-options:    -DWIN32
@@ -280,6 +284,7 @@ test-suite test
     Text.Parsec.ExprFail
     Text.Regex.PCRE.Light.Text
     TimeLog
+    Paths_arbtt
   Build-depends:
       base >= 4.7 && < 5
       , tasty >= 0.7 && < 1.3
@@ -305,6 +310,11 @@ test-suite test
   else
         build-depends: time >= 1.5
   default-language: Haskell98
+  build-tool-depends:
+      arbtt:arbtt-stats
+    , arbtt:arbtt-dump
+    , arbtt:arbtt-import
+    , arbtt:arbtt-recover
 
 source-repository head
   type:     git

--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -282,7 +282,7 @@ test-suite test
     TimeLog
   Build-depends:
       base >= 4.7 && < 5
-      , tasty >= 0.7 && < 1.2
+      , tasty >= 0.7 && < 1.3
       , tasty-golden >= 2.2.0.2  && < 2.4
       , tasty-hunit >= 0.2  && < 0.11
       , process-extras >= 0.2 && < 0.8

--- a/src/Stats.hs
+++ b/src/Stats.hs
@@ -23,7 +23,7 @@ import Data.List
 import Data.Ord
 import Text.Printf
 import qualified Data.Map.Strict as M
-import qualified Data.Set.Strict as S
+import qualified Data.Set as S
 import Data.MyText (Text,pack,unpack)
 import Data.Function (on)
 #if MIN_VERSION_time(1,5,0)
@@ -86,7 +86,7 @@ defaultReportOptions = ReportOptions
 
 -- Data format semantically representing the result of a report, including the
 -- title
-type Interval = (String,String,String,String) 
+type Interval = (String,String,String,String)
 data ReportResults =
         ListOfFields String [(String, String)]
         | ListOfTimePercValues String [(String, String, Double)]
@@ -98,8 +98,8 @@ data ReportResults =
 
 
 filterPredicate :: [Filter] -> TimeLogEntry (Ctx, ActivityData) -> Bool
-filterPredicate filters tl = 
-       all (\flag -> case flag of 
+filterPredicate filters tl =
+       all (\flag -> case flag of
                 Exclude act  -> excludeTag act tl
                 Only act     -> onlyTag act tl
                 GeneralCond s-> applyCond s (cTimeZone (fst (tlData tl))) M.empty tl) filters
@@ -110,8 +110,8 @@ filterActivity fs = filter (applyActivityFilter fs)
 applyActivityFilter :: [ActivityFilter] -> Activity -> Bool
 applyActivityFilter fs act = all go fs
     where go (ExcludeActivity matcher) = not (matchActivityMatcher matcher act)
-          go (OnlyActivity matcher)    =      matchActivityMatcher matcher act 
-                                
+          go (OnlyActivity matcher)    =      matchActivityMatcher matcher act
+
 excludeTag matcher = not . any (matchActivityMatcher matcher) . snd . tlData
 onlyTag matcher = any (matchActivityMatcher matcher) . snd . tlData
 
@@ -122,7 +122,7 @@ matchActivityMatcher :: ActivityMatcher -> Activity -> Bool
 matchActivityMatcher (MatchActivity act1) act2 = act1 == act2
 matchActivityMatcher (MatchCategory cat) act2 = Just cat == activityCategory act2
 
-parseActivityMatcher :: String -> ActivityMatcher 
+parseActivityMatcher :: String -> ActivityMatcher
 parseActivityMatcher str | last str == ':' = MatchCategory (pack (init str))
                          | otherwise       = MatchActivity (read str)
 
@@ -320,7 +320,7 @@ processIntervalReport :: TimeZone -> ReportOptions -> String -> (ActivityData -
 processIntervalReport tz opts title extr = runOnIntervals  go1 go2
   where
     go1 :: LeftFold (TimeLogEntry (Ctx, ActivityData)) [Interval]
-    go1 = go3 `mapElems` fmap (extr . snd) 
+    go1 = go3 `mapElems` fmap (extr . snd)
     go3 :: LeftFold (TimeLogEntry (Maybe String)) [Interval]
     go3 = runOnGroups sameGroup go4 (onJusts toList)
     sameGroup tl1 tl2 =
@@ -341,10 +341,10 @@ processIntervalReport tz opts title extr = runOnIntervals  go1 go2
         (fromJust <$> lfLast)
     go2 :: LeftFold [Interval] ReportResults
     go2 = ListOfIntervals title <$> concatFold
-        
+
 
 {-
-        ((extr. snd) `filterWith` 
+        ((extr. snd) `filterWith`
             runOnIntervals
                 (runOnGroups ((==) `on` tlData)
 -}
@@ -413,7 +413,7 @@ listOfIntervals dats =
 
 -- The reporting of "General Information" is not supported for the
 -- comma-separated output format.
-renderXSV (ListOfFields title dats) = 
+renderXSV (ListOfFields title dats) =
     error ("\"" ++ title ++ "\"" ++ " not supported for this output format")
 
 renderXSV (ListOfTimePercValues _ dats) = listOfValues dats
@@ -451,7 +451,7 @@ showTimeDiffHuman t = go False $ zip [days,hours,mins,secs] ["d","h","m","s"]
         days  =  s `div` (24*60*60)
         hours = (s `div` (60*60)) `mod` 24
         mins  = (s `div` 60) `mod` 60
-        secs  =  s `mod` 60 
+        secs  =  s `mod` 60
         go False []         = "0s"
         go True  []         = ""
 --      go True  vs         | all (==0) (map fst vs) = concat (replicate (length vs) "   ")
@@ -464,13 +464,13 @@ showTimeDiffMachine t = printf "%d:%02d:%02d" hours mins secs
   where s = round t :: Integer
         hours = s `div` (60*60)
         mins  = (s `div` 60) `mod` 60
-        secs  =  s `mod` 60 
+        secs  =  s `mod` 60
 
 showAsLocalTime :: TimeZone -> UTCTime -> String
 showAsLocalTime tz = formatTime defaultTimeLocale "%x %X" . utcToZonedTime tz
 
 underline :: String -> String
-underline str = unlines 
+underline str = unlines
     [ str
     , map (const '=') str
     ]

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -28,11 +28,10 @@ import           Data.Time.Clock
 
 main = do
     setEnv "TZ" "UTC" -- to make tests reproducible
-    distDir <- fromMaybe "dist" `liftM` lookupEnv "HASKELL_DIST_DIR"
-    defaultMain (tests distDir)
+    defaultMain tests
 
-tests :: FilePath -> TestTree
-tests distDir = testGroup "Tests" [goldenTests distDir, regressionTests, parserTests]
+tests :: TestTree
+tests = testGroup "Tests" [goldenTests, regressionTests, parserTests]
 
 regressionTests :: TestTree
 regressionTests = testGroup "Regression tests"
@@ -60,47 +59,47 @@ regressionTests = testGroup "Regression tests"
     ]
 
 
-goldenTests :: FilePath -> TestTree
-goldenTests distDir = testGroup "Golden tests"
+goldenTests :: TestTree
+goldenTests = testGroup "Golden tests"
     [ goldenVsString "dump small"
         "tests/small_dump.out" $
-        run (distDir ++ "/build/arbtt-dump/arbtt-dump") ["-f","tests/small.log", "-t", "Show"] B.empty
+        run "arbtt-dump" ["-f","tests/small.log", "-t", "Show"] B.empty
     , goldenVsFile "import small"
         "tests/small_import.out" "tests/small_import.out.actual" $ void $ do
         tryIOError $ removeFile "tests/small_import.out.actual"
         B.readFile "tests/small_import.in" >>=
-            run (distDir ++ "/build/arbtt-import/arbtt-import") ["-f","tests/small_import.out.actual"]
+            run "arbtt-import" ["-f","tests/small_import.out.actual"]
     , goldenVsString "dump small JSON"
         "tests/small_dump_json.out" $
-        run (distDir ++ "/build/arbtt-dump/arbtt-dump") ["-f","tests/small.log", "-t", "JSON"] B.empty
+        run "arbtt-dump" ["-f","tests/small.log", "-t", "JSON"] B.empty
     , goldenVsFile "import small JSON"
         "tests/small_import_json.out" "tests/small_import_json.out.actual" $ void $ do
         tryIOError $ removeFile "tests/small_import_json.out.actual"
         B.readFile "tests/small_import_json.in" >>=
-            run (distDir ++ "/build/arbtt-import/arbtt-import") ["-f","tests/small_import_json.out.actual", "-t", "JSON"]
+            run "arbtt-import" ["-f","tests/small_import_json.out.actual", "-t", "JSON"]
     , goldenVsFile "import small JSON (list)"
         "tests/small_import_json_list.out" "tests/small_import_json_list.out.actual" $ void $ do
         tryIOError $ removeFile "tests/small_import_json_list.out.actual"
         B.readFile "tests/small_import_json_list.in" >>=
-            run (distDir ++ "/build/arbtt-import/arbtt-import") ["-f","tests/small_import_json_list.out.actual", "-t", "JSON"]
+            run "arbtt-import" ["-f","tests/small_import_json_list.out.actual", "-t", "JSON"]
     , goldenVsFile "recover small"
         "tests/small_borked_recover.out" "tests/small_borked_recover.out.actual" $ void $
-        run (distDir ++ "/build/arbtt-recover/arbtt-recover") ["-i","tests/small_borked_recover.out", "-o", "tests/small_borked_recover.out.actual"] B.empty
+        run "arbtt-recover" ["-i","tests/small_borked_recover.out", "-o", "tests/small_borked_recover.out.actual"] B.empty
     , goldenVsString "stats small"
         "tests/small_stats.out" $
-        run (distDir ++ "/build/arbtt-stats/arbtt-stats") ["--logfile", "tests/small.log", "--categorize", "tests/small.cfg"] B.empty
+        run "arbtt-stats" ["--logfile", "tests/small.log", "--categorize", "tests/small.cfg"] B.empty
     , goldenVsString "stats small csv"
         "tests/small_stats_csv.out" $
-        run (distDir ++ "/build/arbtt-stats/arbtt-stats") ["--logfile", "tests/small.log", "--categorize", "tests/small.cfg", "--output-format", "csv"] B.empty
+        run "arbtt-stats" ["--logfile", "tests/small.log", "--categorize", "tests/small.cfg", "--output-format", "csv"] B.empty
     , goldenVsString "stats small unicode"
         "tests/unicode_stats.out" $
-        run (distDir ++ "/build/arbtt-stats/arbtt-stats") ["--logfile", "tests/unicode.log", "--categorize", "tests/unicode.cfg"] B.empty
+        run "arbtt-stats" ["--logfile", "tests/unicode.log", "--categorize", "tests/unicode.cfg"] B.empty
     , goldenVsString "stats gap handling"
         "tests/gap-handling.out" $
-        run (distDir ++ "/build/arbtt-stats/arbtt-stats") ["--logfile", "tests/gap-handling.log", "--categorize", "tests/gap-handling.cfg", "--intervals", "Program:"] B.empty
+        run "arbtt-stats" ["--logfile", "tests/gap-handling.log", "--categorize", "tests/gap-handling.cfg", "--intervals", "Program:"] B.empty
     , goldenVsString "condition binding stats"
         "tests/condition_bindings_stats.out" $
-        run (distDir ++ "/build/arbtt-stats/arbtt-stats") ["--logfile", "tests/small.log", "--categorize", "tests/condition_bindings.cfg"] B.empty
+        run "arbtt-stats" ["--logfile", "tests/small.log", "--categorize", "tests/condition_bindings.cfg"] B.empty
     ]
 
 testParser env parser input = do


### PR DESCRIPTION
Prepending "dist/build/.../" to the program name for the golden tests wasn't working in Travis.
    
Use the new `build-tool-depends` option so that Cabal can run tests with executable build paths added to the PATH.
    
Tested with cabal 2.4 new-test.
