### PR TITLE
Record screen saver/locker status for inactivity tagging

### DIFF
--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -93,7 +93,8 @@ executable arbtt-capture
                 Capture.X11
                 System.Locale.SetLocale
             build-depends:
-                X11 >= 1.9
+                X11 >= 1.9,
+                dbus >= 1.0
     default-language: Haskell98
 
 executable arbtt-stats

--- a/categorize.cfg
+++ b/categorize.cfg
@@ -17,6 +17,9 @@ aliases (
 -- causes this sample to be ignored by default.
 $idle > 60 ==> tag inactive,
 
+-- TODO
+$screensaver ==> tag inactive,
+
 -- A rule that matches on a list of strings
 current window $program == ["Navigator","galeon"] ==> tag Web,
 

--- a/doc/arbtt.xml
+++ b/doc/arbtt.xml
@@ -231,6 +231,10 @@
     </para>
 
     <para>
+      The variable <literal>$screensaver</literal> …
+    </para>
+
+    <para>
       When applying the rules, the categorizer has a notion of
       the <emphasis>window in scope</emphasis>, and the variables
       <literal>$title</literal>, <literal>$program</literal> and
@@ -421,6 +425,7 @@
          <nonterminal def="#g-timediff"/> </rhs>
             <rhs> <nonterminal def="#g-date"/> <nonterminal def="#g-cmpop"/>
          <nonterminal def="#g-date"/> </rhs>
+            <rhs> <quote>$screensaver</quote> </rhs>
             <rhs> <quote>current window</quote> <nonterminal def="#g-cond"/> </rhs>
             <rhs> <quote>any window</quote> <nonterminal def="#g-cond"/> </rhs>
             <rhs> <quote>$</quote> Literal </rhs>

--- a/src/Capture/OSX.hs
+++ b/src/Capture/OSX.hs
@@ -21,5 +21,6 @@ captureData = do
                 ) titles
 
         it <- fromIntegral `fmap` getIdleTime
+        -- TODO: screen saver/locker
 
-        return $ CaptureData winData it (T.pack "")
+        return $ CaptureData winData it (T.pack "") False

--- a/src/Capture/Win32.hs
+++ b/src/Capture/Win32.hs
@@ -25,5 +25,6 @@ captureData = do
                 ) titles
 
         it <- fromIntegral `fmap` getIdleTime
+        -- TODO: screen saver/locker
 
-        return $ CaptureData winData it (T.pack "")
+        return $ CaptureData winData it (T.pack "") False

--- a/src/Capture/X11.hs
+++ b/src/Capture/X11.hs
@@ -1,19 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Capture.X11 where
 
 import Data
 import Graphics.X11
 import Graphics.X11.Xlib.Extras
 import Control.Monad
-import Control.Exception (bracket)
+import Control.Exception (catch, bracket)
 import System.IO.Error (catchIOError)
 import Control.Applicative
+import Data.Either
 import Data.Maybe
 import Data.Time.Clock
 import System.IO
 import qualified Data.MyText as T
 
 import System.Locale.SetLocale
-import Graphics.X11.XScreenSaver (getXIdleTime, compiledWithXScreenSaver)
+import Graphics.X11.XScreenSaver
+import qualified DBus as D
+import qualified DBus.Client as D
 
 setupCapture :: IO ()
 setupCapture = do
@@ -68,9 +72,11 @@ captureData = do
             (T.pack <$> getProgramName dpy w)
 
         it <- fromIntegral `fmap` getXIdleTime dpy
+        ss <- isScreenSaverActive dpy
+        sl <- isSessionLocked
 
         closeDisplay dpy
-        return $ CaptureData winData it (T.pack current_desktop)
+        return $ CaptureData winData it (T.pack current_desktop) (ss || sl)
 
 getWindowTitle :: Display -> Window -> IO String
 getWindowTitle dpy =  myFetchName dpy
@@ -120,3 +126,36 @@ myFetchName d w = do
         bracket getProp (xFree . tp_value) extract
             `catchIOError` \_ -> return ""
 
+-- | Check active screen saver using the X11 Screen Saver extension.
+--
+-- This most likely only works with the simple built-in screen saver
+-- configured using @xset s@. Screen savers/lockers such as xscreensaver,
+-- xsecurelock, i3lock, etc. work differently.
+isScreenSaverActive :: Display -> IO Bool
+isScreenSaverActive dpy = do
+    info <- xScreenSaverQueryInfo dpy
+    return $ case info of
+        Just XScreenSaverInfo{xssi_state = ScreenSaverOn} -> True
+        _ -> False
+
+-- TODO: https://unix.stackexchange.com/questions/197032/detect-if-screensaver-is-active
+
+-- | Check whether the current systemd-logind session is marked as locked.
+--
+-- Note that many minimalist screen savers/lockers do not communicate with
+-- systemd-logind, so this often doesn't work either.
+--
+-- TODO: describe this better
+-- dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1/session/self "org.freedesktop.login1.Session.SetLockedHint" boolean:false
+isSessionLocked :: IO Bool
+isSessionLocked = bracket D.connectSystem D.disconnect getLockedHint
+    `catch` (return . const False . D.clientErrorMessage)
+  where
+    dest = "org.freedesktop.login1"
+    -- …/session/auto is the caller's own session if they have one,
+    -- otherwise their user's display session
+    object = "/org/freedesktop/login1/session/auto"
+    interface = "org.freedesktop.login1.Session"
+    property = "LockedHint"
+    methodCall = (D.methodCall object interface property){ D.methodCallDestination = Just dest }
+    getLockedHint c = fmap (fromRight False) $ D.getPropertyValue c methodCall

--- a/src/Data.hs
+++ b/src/Data.hs
@@ -36,11 +36,12 @@ data CaptureData = CaptureData
         , cLastActivity :: Integer -- ^ in milli-seconds
         , cDesktop :: Text
                 -- ^ Current desktop name
+        , cScreenSaver :: Bool -- ^ Screen saver or locker active?
         }
   deriving (Show, Read)
 
 instance NFData CaptureData where
-    rnf (CaptureData a b c) = a `deepseq` b `deepseq` c `deepseq` ()
+    rnf (CaptureData a b c d) = a `deepseq` b `deepseq` c `deepseq` d `deepseq` ()
 
 type ActivityData = [Activity]
 
@@ -110,18 +111,22 @@ instance StringReferencingBinary CaptureData where
 -- Versions:
 -- 1 First version
 -- 2 Using ListOfStringable
+-- 3 Add cDesktop
+-- 4 Add cScreenSaver
  ls_put strs cd = do
         -- A version tag
-        putWord8 3
+        putWord8 4
         ls_put strs (cWindows cd)
         ls_put strs (cLastActivity cd)
         ls_put strs (cDesktop cd)
+        ls_put strs (cScreenSaver cd)
  ls_get strs = do
         v <- getWord8
         case v of
-         1 -> CaptureData <$> get <*> get <*> pure ""
-         2 -> CaptureData <$> ls_get strs <*> ls_get strs <*> pure ""
-         3 -> CaptureData <$> ls_get strs <*> ls_get strs <*> ls_get strs
+         1 -> CaptureData <$> get <*> get <*> pure "" <*> pure False
+         2 -> CaptureData <$> ls_get strs <*> ls_get strs <*> pure "" <*> pure False
+         3 -> CaptureData <$> ls_get strs <*> ls_get strs <*> ls_get strs <*> pure False
+         4 -> CaptureData <$> ls_get strs <*> ls_get strs <*> ls_get strs <*> ls_get strs
          _ -> error $ "Unsupported CaptureData version tag " ++ show v ++ "\n" ++
                       "You can try to recover your data using arbtt-recover."
 

--- a/src/DumpFormat.hs
+++ b/src/DumpFormat.hs
@@ -42,7 +42,8 @@ instance ToJSON (TimeLogEntry CaptureData) where
         "rate" .= tlRate,
         "inactive" .= cLastActivity tlData,
         "windows" .= map (\(a,t,p) -> object ["active" .= a, "title" .= t, "program" .= p]) (cWindows tlData),
-        "desktop" .= cDesktop tlData
+        "desktop" .= cDesktop tlData,
+        "screensaver" .= cScreenSaver tlData
         ]
 
 instance FromJSON (TimeLogEntry CaptureData) where
@@ -55,6 +56,7 @@ instance FromJSON (TimeLogEntry CaptureData) where
                 (,,) <$> v .: "active" <*> v .: "title" <*> v .: "program"
             ) . toList)
         cDesktop <- v .: "desktop"
+        cScreenSaver <- v .: "screensaver"
         let tlData = CaptureData {..}
         let entry = TimeLogEntry {..}
         pure entry
@@ -71,7 +73,7 @@ dumpActivity :: TimeLog (CaptureData, TimeZone, ActivityData) -> IO ()
 dumpActivity = mapM_ go
  where
     go tle = do
-        dumpHeader tz (tlTime tle) (cLastActivity cd)
+        dumpHeader tz (tlTime tle) (cLastActivity cd) (cScreenSaver cd)
         dumpDesktop (cDesktop cd)
         mapM_ dumpWindow (cWindows cd)
         dumpTags ad
@@ -82,11 +84,12 @@ dumpTags :: ActivityData -> IO ()
 dumpTags = mapM_ go
   where go act = printf "    %s\n" (show act)
 
-dumpHeader :: TimeZone -> UTCTime -> Integer -> IO ()
-dumpHeader tz time lastActivity = do
-    printf "%s (%dms inactive):\n"
+dumpHeader :: TimeZone -> UTCTime -> Integer -> Bool -> IO ()
+dumpHeader tz time lastActivity screenSaver = do
+    printf "%s (%dms inactive%s):\n"
         (formatTime defaultTimeLocale "%F %X" (utcToLocalTime tz time))
         lastActivity
+        (if screenSaver then ", screen saver/locker active" else [])
 
 dumpWindow :: (Bool, Text, Text) -> IO ()
 dumpWindow (active, title, program) = do
@@ -102,7 +105,7 @@ dumpDesktop d
 
 dumpSample :: TimeZone -> TimeLogEntry CaptureData -> IO ()
 dumpSample tz tle = do
-    dumpHeader tz (tlTime tle) (cLastActivity (tlData tle))
+    dumpHeader tz (tlTime tle) (cLastActivity (tlData tle)) (cScreenSaver (tlData tle))
     dumpDesktop (cDesktop (tlData tle))
     mapM_ dumpWindow (cWindows (tlData tle))
 

--- a/src/UpgradeLog1.hs
+++ b/src/UpgradeLog1.hs
@@ -57,6 +57,6 @@ upgrade :: TimeLog CaptureData -> D.TimeLog D.CaptureData
 upgrade = map $ \(TimeLogEntry a b c) -> D.TimeLogEntry a b (upgradeCD c)
 
 upgradeCD :: CaptureData -> D.CaptureData
-upgradeCD (CaptureData a b) = D.CaptureData (map (\(b,s1,s2) -> (b, T.pack s1, T.pack s2)) a) b (T.pack "")
+upgradeCD (CaptureData a b) = D.CaptureData (map (\(b,s1,s2) -> (b, T.pack s1, T.pack s2)) a) b (T.pack "") False
 
 


### PR DESCRIPTION
Tracking inactivity via idle time is unsuitable if one wants to account for activities such as watching movies or reading difficult texts. As media players usually keep the screen saver/locker from triggering, tracking inactivity that way might be more accurate, as long as the screen saver trigger is set to low enough duration or the user diligently locks their screen when walking away.

Currently implemented for X11 only, and even that implementation supports only a few desktop environments.

Closes: https://github.com/nomeata/arbtt/issues/39

---

- [ ] support for gnome/kde screensavers
- [ ] support for Win32/OSX (probably won't to tackle this myself)
- [ ] documentation