### PR TITLE
Speed up arbtt-stats --filter

### DIFF
--- a/src/stats-main.hs
+++ b/src/stats-main.hs
@@ -202,6 +202,7 @@ main = do
      exitFailure
 
   let filters = (if optAlsoInactive flags then id else (defaultFilter:)) $ optFilters flags
+  filter <- mkFilterPredicate filters
 
   let rep = case optReports flags of
                 [] -> TotalTime
@@ -210,7 +211,7 @@ main = do
   let repeater = foldr (.) id $ map (processRepeater tz) (optRepeater flags)
 
   let opts = optReportOptions flags
-  let fold = filterPredicate filters `adjoin` repeater (processReport tz opts rep)
+  let fold = filter `adjoin` repeater (processReport tz opts rep)
   let result = runLeftFold fold allTags
 
   -- Force the results a bit, to ensure the progress bar to be shown before the title


### PR DESCRIPTION
filterPredicate used to parse the filter again for each TimeLogEntry, presumably to account for the TimeZone potentially being different, but in practice it's always the same. This commit speeds it up by making applyCond analogous to readCategorizer: get current timezone, parse condition, return function that applies it.

If we ever want to support different time zones for individual TimeLogEntries, we'll need to adapt both readCategorizer and mkApplyCond: either memoize/cache the parse for each time zone needed, or preferably do comparisons/matching in local time, transforming the parsed datetime to the necessary time zone first.

before:

    $ hyperfine 'arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log'
    Benchmark #1: arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log
      Time (mean ± σ):      21.2 ms ±   0.6 ms    [User: 19.6 ms, System: 1.6 ms]

    $ hyperfine 'arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00"'
    Benchmark #1: arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00"
      Time (mean ± σ):      80.1 ms ±   0.6 ms    [User: 78.1 ms, System: 2.1 ms]
      Range (min … max):    79.4 ms …  81.7 ms    37 runs

    $ hyperfine 'arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00 && \$sampleage < 24:00"'
    Benchmark #1: arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00 && \$sampleage < 24:00"
      Time (mean ± σ):     120.9 ms ±   7.1 ms    [User: 118.5 ms, System: 2.3 ms]
      Range (min … max):   117.8 ms … 152.8 ms    24 runs

after:

    $ hyperfine 'arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log'
    Benchmark #1: arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log
      Time (mean ± σ):      21.6 ms ±   0.8 ms    [User: 19.9 ms, System: 1.6 ms]
      Range (min … max):    20.9 ms …  28.6 ms    134 runs

    $ hyperfine 'arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00"'
    Benchmark #1: arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00"
      Time (mean ± σ):      19.6 ms ±   0.8 ms    [User: 18.2 ms, System: 1.5 ms]
      Range (min … max):    18.9 ms …  26.4 ms    131 runs

    $ hyperfine 'arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00 && \$sampleage < 24:00"'
    Benchmark #1: arbtt-stats --logfile=/home/tomi/.arbtt/capture-:1.log --filter="\$sampleage < 24:00 && \$sampleage < 24:00"
      Time (mean ± σ):      20.1 ms ±   0.9 ms    [User: 18.7 ms, System: 1.5 ms]
      Range (min … max):    19.3 ms …  27.0 ms    130 runs

(On my primary session capture.log, it was 2 seconds vs 10 seconds, which is quite noticeable. I'll need to deal with log rotation sooner or later, but this fruit was hanging lower. :-))