### PR TITLE
Bump upper bounds for tasty and tasty-golden

### DIFF
--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -288,8 +288,8 @@ test-suite test
     TimeLog
   Build-depends:
       base >= 4.7 && < 5
-      , tasty >= 0.7 && < 1.3
-      , tasty-golden >= 2.2.0.2  && <= 2.3.3.2
+      , tasty >= 0.7 && < 1.5
+      , tasty-golden >= 2.2.0.2  && <= 2.3.4
       , tasty-hunit >= 0.2  && < 0.11
       , process-extras >= 0.2 && < 0.8
       , deepseq


### PR DESCRIPTION
Allows recent `tasty 1.4.x` and `tasty-golden 2.3.4`.