### PR TITLE
Support ghc-9.0

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,8 @@ jobs:
         ghc:
         - '8.6.5'
         - '8.8.4'
-        - '8.10.2'
+        - '8.10.7'
+        - '9.0.1'
         os:
         - ubuntu-latest
         # TODO: - windows-latest
@@ -18,7 +19,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
-        key: cabal-store-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project', 'cabal.project.freeze') }}
+        key: cabal-store-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('arbtt.cabal') }}
         restore-keys: cabal-store-${{ runner.os }}-${{ matrix.ghc }}-
 
     - uses: actions/checkout@v2

--- a/doc/arbtt.xml
+++ b/doc/arbtt.xml
@@ -98,9 +98,9 @@
   <title>Installation</title>
 
   <sect2>
-    <title>Obtaining arbtt</title>>
+    <title>Obtaining arbtt</title>
     <para>
-      See the project website <ulink url="http://arbtt.nomeata.de/#install">for installation instructions</ulink>.
+      See the project website <ulink url="https://arbtt.nomeata.de/#install">for installation instructions</ulink>.
     </para>
   </sect2>
 

--- a/src/Data/Conduit/Binary.hs
+++ b/src/Data/Conduit/Binary.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE CPP, RankNTypes #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- | Functions for interacting with bytes.
+-- | /NOTE/ It is recommended to start using "Data.Conduit.Combinators" instead
+-- of this module.
+--
+-- Functions for interacting with bytes.
 --
 -- For many purposes, it's recommended to use the conduit-combinators library,
 -- which provides a more complete set of functions.
@@ -13,26 +16,26 @@ module Data.Conduit.Binary
       -- order to run such code, you will need to use @runResourceT@.
 
       -- ** Sources
-      sourceFile
-    , sourceHandle
-    , sourceHandleUnsafe
-    , sourceIOHandle
+      CC.sourceFile
+    , CC.sourceHandle
+    , CC.sourceHandleUnsafe
+    , CC.sourceIOHandle
     , sourceFileRange
     , sourceHandleRange
     , sourceHandleRangeWithBuffer
-    , withSourceFile
+    , CC.withSourceFile
       -- ** Sinks
-    , sinkFile
-    , sinkFileCautious
-    , sinkTempFile
-    , sinkSystemTempFile
-    , sinkHandle
-    , sinkIOHandle
-    , sinkHandleBuilder
-    , sinkHandleFlush
-    , withSinkFile
-    , withSinkFileBuilder
-    , withSinkFileCautious
+    , CC.sinkFile
+    , CC.sinkFileCautious
+    , CC.sinkTempFile
+    , CC.sinkSystemTempFile
+    , CC.sinkHandle
+    , CC.sinkIOHandle
+    , CC.sinkHandleBuilder
+    , CC.sinkHandleFlush
+    , CC.withSinkFile
+    , CC.withSinkFileBuilder
+    , CC.withSinkFileCautious
       -- ** Conduits
     , conduitFile
     , conduitHandle
@@ -56,20 +59,17 @@ module Data.Conduit.Binary
     , Data.Conduit.Binary.lines
     ) where
 
-import qualified Data.ByteString.Builder as BB
-import qualified Data.Streaming.FileRead as FR
+import qualified Data.Conduit.Combinators as CC
 import Prelude hiding (head, take, drop, takeWhile, dropWhile, mapM_)
 import qualified Data.ByteString as S
 import Data.ByteString.Unsafe (unsafeUseAsCString)
 import qualified Data.ByteString.Lazy as L
 import Data.Conduit
 import Data.Conduit.List (sourceList, consume)
-import qualified Data.Conduit.List as CL
-import Control.Exception (assert, finally, bracket)
-import Control.Monad (unless, when)
+import Control.Exception (assert, finally)
+import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO, MonadIO)
-import Control.Monad.IO.Unlift
-import Control.Monad.Trans.Resource (allocate, release)
+import Control.Monad.Trans.Resource (allocate, release, MonadThrow (..))
 import Control.Monad.Trans.Class (lift)
 import qualified System.IO as IO
 import Data.Word (Word8, Word64)
@@ -78,140 +78,18 @@ import Control.Applicative ((<$>))
 #endif
 import System.Directory (getTemporaryDirectory, removeFile)
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
-import Data.ByteString.Internal (ByteString (PS), inlinePerformIO)
+import Data.ByteString.Internal (ByteString (PS), accursedUnutterablePerformIO)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.ForeignPtr (touchForeignPtr)
 import Foreign.Ptr (plusPtr, castPtr)
 import Foreign.Storable (Storable, peek, sizeOf)
-import GHC.ForeignPtr           (mallocPlainForeignPtrBytes)
 import Control.Monad.Trans.Resource (MonadResource)
-import Control.Monad.Catch (MonadThrow (..))
 import Control.Exception (Exception)
 import Data.Typeable (Typeable)
 import Foreign.Ptr (Ptr)
 #ifndef ALLOW_UNALIGNED_ACCESS
 import Foreign.Marshal (alloca, copyBytes)
 #endif
-import System.Directory (renameFile)
-import System.FilePath (takeDirectory, takeFileName, (<.>))
-import System.IO (hClose, openBinaryTempFile)
-import Control.Exception (throwIO, catch)
-import System.IO.Error (isDoesNotExistError)
-import qualified Data.ByteString.Builder as BB
-
--- | Stream the contents of a file as binary data.
---
--- Since 0.3.0
-sourceFile :: MonadResource m
-           => FilePath
-           -> Producer m S.ByteString
-sourceFile fp =
-    bracketP
-        (FR.openFile fp)
-         FR.closeFile
-         loop
-  where
-    loop h = do
-        bs <- liftIO $ FR.readChunk h
-        unless (S.null bs) $ do
-            yield bs
-            loop h
-
--- | Stream the contents of a 'IO.Handle' as binary data. Note that this
--- function will /not/ automatically close the @Handle@ when processing
--- completes, since it did not acquire the @Handle@ in the first place.
---
--- Since 0.3.0
-sourceHandle :: MonadIO m
-             => IO.Handle
-             -> Producer m S.ByteString
-sourceHandle h =
-    loop
-  where
-    loop = do
-        bs <- liftIO (S.hGetSome h defaultChunkSize)
-        if S.null bs
-            then return ()
-            else yield bs >> loop
-
--- | Same as @sourceHandle@, but instead of allocating a new buffer for each
--- incoming chunk of data, reuses the same buffer. Therefore, the @ByteString@s
--- yielded by this function are not referentially transparent between two
--- different @yield@s.
---
--- This function will be slightly more efficient than @sourceHandle@ by
--- avoiding allocations and reducing garbage collections, but should only be
--- used if you can guarantee that you do not reuse a @ByteString@ (or any slice
--- thereof) between two calls to @await@.
---
--- Since 1.0.12
-sourceHandleUnsafe :: MonadIO m => IO.Handle -> Source m ByteString
-sourceHandleUnsafe handle = do
-    fptr <- liftIO $ mallocPlainForeignPtrBytes defaultChunkSize
-    let ptr = unsafeForeignPtrToPtr fptr
-        loop = do
-            count <- liftIO $ IO.hGetBuf handle ptr defaultChunkSize
-            when (count > 0) $ do
-                yield (PS fptr 0 count)
-                loop
-
-    loop
-
-    liftIO $ touchForeignPtr fptr
-
--- | An alternative to 'sourceHandle'.
--- Instead of taking a pre-opened 'IO.Handle', it takes an action that opens
--- a 'IO.Handle' (in read mode), so that it can open it only when needed
--- and close it as soon as possible.
---
--- Since 0.3.0
-sourceIOHandle :: MonadResource m
-               => IO IO.Handle
-               -> Producer m S.ByteString
-sourceIOHandle alloc = bracketP alloc IO.hClose sourceHandle
-
--- | Stream all incoming data to the given 'IO.Handle'. Note that this function
--- does /not/ flush and will /not/ close the @Handle@ when processing completes.
---
--- Since 0.3.0
-sinkHandle :: MonadIO m
-           => IO.Handle
-           -> Consumer S.ByteString m ()
-sinkHandle h = awaitForever (liftIO . S.hPut h)
-
--- | Stream incoming builders, executing them directly on the buffer of the
--- given 'IO.Handle'. Note that this function does /not/ automatically close the
--- @Handle@ when processing completes.
--- Pass 'Data.ByteString.Builder.Extra.flush' to flush the buffer.
---
--- @since 1.2.2
-sinkHandleBuilder :: MonadIO m => IO.Handle -> ConduitM BB.Builder o m ()
-sinkHandleBuilder h = awaitForever (liftIO . BB.hPutBuilder h)
-
--- | Stream incoming @Flush@es, executing them on @IO.Handle@
--- Note that this function does /not/ automatically close the @Handle@ when
--- processing completes
---
--- @since 1.2.2
-sinkHandleFlush :: MonadIO m
-                => IO.Handle
-                -> ConduitM (Flush S.ByteString) o m ()
-sinkHandleFlush h =
-  awaitForever $ \mbs -> liftIO $
-  case mbs of
-    Chunk bs -> S.hPut h bs
-    Flush -> IO.hFlush h
-
--- | An alternative to 'sinkHandle'.
--- Instead of taking a pre-opened 'IO.Handle', it takes an action that opens
--- a 'IO.Handle' (in write mode), so that it can open it only when needed
--- and close it as soon as possible.
---
--- Since 0.3.0
-sinkIOHandle :: MonadResource m
-             => IO IO.Handle
-             -> Consumer S.ByteString m ()
-sinkIOHandle alloc = bracketP alloc IO.hClose sinkHandle
 
 -- | Stream the contents of a file as binary data, starting from a certain
 -- offset and only consuming up to a certain number of bytes.
@@ -221,7 +99,7 @@ sourceFileRange :: MonadResource m
                 => FilePath
                 -> Maybe Integer -- ^ Offset
                 -> Maybe Integer -- ^ Maximum count
-                -> Producer m S.ByteString
+                -> ConduitT i S.ByteString m ()
 sourceFileRange fp offset count = bracketP
     (IO.openBinaryFile fp IO.ReadMode)
     IO.hClose
@@ -235,7 +113,7 @@ sourceHandleRange :: MonadIO m
                   => IO.Handle
                   -> Maybe Integer -- ^ Offset
                   -> Maybe Integer -- ^ Maximum count
-                  -> Producer m S.ByteString
+                  -> ConduitT i S.ByteString m ()
 sourceHandleRange handle offset count =
   sourceHandleRangeWithBuffer handle offset count defaultChunkSize
 
@@ -249,7 +127,7 @@ sourceHandleRangeWithBuffer :: MonadIO m
                   -> Maybe Integer -- ^ Offset
                   -> Maybe Integer -- ^ Maximum count
                   -> Int -- ^ Buffer size
-                  -> Producer m S.ByteString
+                  -> ConduitT i S.ByteString m ()
 sourceHandleRangeWithBuffer handle offset count buffer = do
     case offset of
         Nothing -> return ()
@@ -276,79 +154,13 @@ sourceHandleRangeWithBuffer handle offset count buffer = do
                     yield bs
                     pullLimited c'
 
--- | Stream all incoming data to the given file.
---
--- Since 0.3.0
-sinkFile :: MonadResource m
-         => FilePath
-         -> Consumer S.ByteString m ()
-sinkFile fp = sinkIOHandle (IO.openBinaryFile fp IO.WriteMode)
-
--- | Cautious version of 'sinkFile'. The idea here is to stream the
--- values to a temporary file in the same directory of the destination
--- file, and only on successfully writing the entire file, moves it
--- atomically to the destination path.
---
--- In the event of an exception occurring, the temporary file will be
--- deleted and no move will be made. If the application shuts down
--- without running exception handling (such as machine failure or a
--- SIGKILL), the temporary file will remain and the destination file
--- will be untouched.
---
--- @since 1.1.14
-sinkFileCautious
-  :: MonadResource m
-  => FilePath
-  -> ConduitM S.ByteString o m ()
-sinkFileCautious fp =
-    bracketP (cautiousAcquire fp) cautiousCleanup inner
-  where
-    inner (tmpFP, h) = do
-        sinkHandle h
-        liftIO $ do
-            hClose h
-            renameFile tmpFP fp
-
--- | Stream data into a temporary file in the given directory with the
--- given filename pattern, and return the temporary filename. The
--- temporary file will be automatically deleted when exiting the
--- active 'ResourceT' block, if it still exists.
---
--- @since 1.1.15
-sinkTempFile :: MonadResource m
-             => FilePath -- ^ temp directory
-             -> String -- ^ filename pattern
-             -> ConduitM ByteString o m FilePath
-sinkTempFile tmpdir pattern = do
-    (_releaseKey, (fp, h)) <- allocate
-        (IO.openBinaryTempFile tmpdir pattern)
-        (\(fp, h) -> IO.hClose h `finally` (removeFile fp `Control.Exception.catch` \e ->
-            if isDoesNotExistError e
-                then return ()
-                else throwIO e))
-    sinkHandle h
-    liftIO $ IO.hClose h
-    return fp
-
--- | Same as 'sinkTempFile', but will use the default temp file
--- directory for the system as the first argument.
---
--- @since 1.1.15
-sinkSystemTempFile
-    :: MonadResource m
-    => String -- ^ filename pattern
-    -> ConduitM ByteString o m FilePath
-sinkSystemTempFile pattern = do
-    dir <- liftIO getTemporaryDirectory
-    sinkTempFile dir pattern
-
 -- | Stream the contents of the input to a file, and also send it along the
 -- pipeline. Similar in concept to the Unix command @tee@.
 --
 -- Since 0.3.0
 conduitFile :: MonadResource m
             => FilePath
-            -> Conduit S.ByteString m S.ByteString
+            -> ConduitT S.ByteString S.ByteString m ()
 conduitFile fp = bracketP
     (IO.openBinaryFile fp IO.WriteMode)
     IO.hClose
@@ -359,7 +171,7 @@ conduitFile fp = bracketP
 -- does not close the handle on completion. Related to: @conduitFile@.
 --
 -- Since 1.0.9
-conduitHandle :: MonadIO m => IO.Handle -> Conduit S.ByteString m S.ByteString
+conduitHandle :: MonadIO m => IO.Handle -> ConduitT S.ByteString S.ByteString m ()
 conduitHandle h = awaitForever $ \bs -> liftIO (S.hPut h bs) >> yield bs
 
 -- | Ensure that only up to the given number of bytes are consumed by the inner
@@ -369,7 +181,7 @@ conduitHandle h = awaitForever $ \bs -> liftIO (S.hPut h bs) >> yield bs
 -- Since 0.3.0
 isolate :: Monad m
         => Int
-        -> Conduit S.ByteString m S.ByteString
+        -> ConduitT S.ByteString S.ByteString m ()
 isolate =
     loop
   where
@@ -389,7 +201,7 @@ isolate =
 -- | Return the next byte from the stream, if available.
 --
 -- Since 0.3.0
-head :: Monad m => Consumer S.ByteString m (Maybe Word8)
+head :: Monad m => ConduitT S.ByteString o m (Maybe Word8)
 head = do
     mbs <- await
     case mbs of
@@ -402,7 +214,7 @@ head = do
 -- | Return all bytes while the predicate returns @True@.
 --
 -- Since 0.3.0
-takeWhile :: Monad m => (Word8 -> Bool) -> Conduit S.ByteString m S.ByteString
+takeWhile :: Monad m => (Word8 -> Bool) -> ConduitT S.ByteString S.ByteString m ()
 takeWhile p =
     loop
   where
@@ -418,7 +230,7 @@ takeWhile p =
 -- | Ignore all bytes while the predicate returns @True@.
 --
 -- Since 0.3.0
-dropWhile :: Monad m => (Word8 -> Bool) -> Consumer S.ByteString m ()
+dropWhile :: Monad m => (Word8 -> Bool) -> ConduitT S.ByteString o m ()
 dropWhile p =
     loop
   where
@@ -433,7 +245,7 @@ dropWhile p =
 -- | Take the given number of bytes, if available.
 --
 -- Since 0.3.0
-take :: Monad m => Int -> Consumer S.ByteString m L.ByteString
+take :: Monad m => Int -> ConduitT S.ByteString o m L.ByteString
 take  0 = return L.empty
 take n0 = go n0 id
   where
@@ -451,7 +263,7 @@ take n0 = go n0 id
 -- | Drop up to the given number of bytes.
 --
 -- Since 0.5.0
-drop :: Monad m => Int -> Consumer S.ByteString m ()
+drop :: Monad m => Int -> ConduitT S.ByteString o m ()
 drop  0 = return ()
 drop n0 = go n0
   where
@@ -470,7 +282,7 @@ drop n0 = go n0
 -- (10), and strip it from the output.
 --
 -- Since 0.3.0
-lines :: Monad m => Conduit S.ByteString m S.ByteString
+lines :: Monad m => ConduitT S.ByteString S.ByteString m ()
 lines =
     loop []
   where
@@ -490,7 +302,7 @@ lines =
 -- | Stream the chunks from a lazy bytestring.
 --
 -- Since 0.5.0
-sourceLbs :: Monad m => L.ByteString -> Producer m S.ByteString
+sourceLbs :: Monad m => L.ByteString -> ConduitT i S.ByteString m ()
 sourceLbs = sourceList . L.toChunks
 
 -- | Stream the input data into a temp file and count the number of bytes
@@ -501,7 +313,7 @@ sourceLbs = sourceList . L.toChunks
 --
 -- Since 1.0.5
 sinkCacheLength :: (MonadResource m1, MonadResource m2)
-                => Sink S.ByteString m1 (Word64, Source m2 S.ByteString)
+                => ConduitT S.ByteString o m1 (Word64, ConduitT i S.ByteString m2 ())
 sinkCacheLength = do
     tmpdir <- liftIO getTemporaryDirectory
     (releaseKey, (fp, h)) <- allocate
@@ -509,9 +321,9 @@ sinkCacheLength = do
         (\(fp, h) -> IO.hClose h `finally` removeFile fp)
     len <- sinkHandleLen h
     liftIO $ IO.hClose h
-    return (len, sourceFile fp >> release releaseKey)
+    return (len, CC.sourceFile fp >> release releaseKey)
   where
-    sinkHandleLen :: MonadResource m => IO.Handle -> Sink S.ByteString m Word64
+    sinkHandleLen :: MonadResource m => IO.Handle -> ConduitT S.ByteString o m Word64
     sinkHandleLen h =
         loop 0
       where
@@ -526,7 +338,7 @@ sinkCacheLength = do
 -- is performed, but rather all content is read into memory strictly.
 --
 -- Since 1.0.5
-sinkLbs :: Monad m => Sink S.ByteString m L.ByteString
+sinkLbs :: Monad m => ConduitT S.ByteString o m L.ByteString
 sinkLbs = fmap L.fromChunks consume
 
 mapM_BS :: Monad m => (Word8 -> m ()) -> S.ByteString -> m ()
@@ -534,9 +346,9 @@ mapM_BS f (PS fptr offset len) = do
     let start = unsafeForeignPtrToPtr fptr `plusPtr` offset
         end = start `plusPtr` len
         loop ptr
-            | ptr >= end = inlinePerformIO (touchForeignPtr fptr) `seq` return ()
+            | ptr >= end = accursedUnutterablePerformIO (touchForeignPtr fptr) `seq` return ()
             | otherwise = do
-                f (inlinePerformIO (peek ptr))
+                f (accursedUnutterablePerformIO (peek ptr))
                 loop (ptr `plusPtr` 1)
     loop start
 {-# INLINE mapM_BS #-}
@@ -544,7 +356,7 @@ mapM_BS f (PS fptr offset len) = do
 -- | Perform a computation on each @Word8@ in a stream.
 --
 -- Since 1.0.10
-mapM_ :: Monad m => (Word8 -> m ()) -> Consumer S.ByteString m ()
+mapM_ :: Monad m => (Word8 -> m ()) -> ConduitT S.ByteString o m ()
 mapM_ f = awaitForever (lift . mapM_BS f)
 {-# INLINE mapM_ #-}
 
@@ -553,7 +365,7 @@ mapM_ f = awaitForever (lift . mapM_BS f)
 -- all unused input as leftovers.
 --
 -- @since 1.1.13
-sinkStorable :: (Monad m, Storable a) => Consumer S.ByteString m (Maybe a)
+sinkStorable :: (Monad m, Storable a) => ConduitT S.ByteString o m (Maybe a)
 sinkStorable = sinkStorableHelper Just (return Nothing)
 
 -- | Same as 'sinkStorable', but throws a 'SinkStorableInsufficientBytes'
@@ -562,13 +374,13 @@ sinkStorable = sinkStorableHelper Just (return Nothing)
 -- construct/deconstruct a @Maybe@ wrapper in the success case.
 --
 -- @since 1.1.13
-sinkStorableEx :: (MonadThrow m, Storable a) => Consumer S.ByteString m a
+sinkStorableEx :: (MonadThrow m, Storable a) => ConduitT S.ByteString o m a
 sinkStorableEx = sinkStorableHelper id (throwM SinkStorableInsufficientBytes)
 
-sinkStorableHelper :: forall m a b. (Monad m, Storable a)
+sinkStorableHelper :: forall m a b o. (Monad m, Storable a)
                    => (a -> b)
-                   -> (Consumer S.ByteString m b)
-                   -> Consumer S.ByteString m b
+                   -> (ConduitT S.ByteString o m b)
+                   -> ConduitT S.ByteString o m b
 sinkStorableHelper wrap failure = do
     start
   where
@@ -587,13 +399,13 @@ sinkStorableHelper wrap failure = do
                             -- looks like we're stuck concating
                             leftover bs
                             lbs <- take size
-                            let bs = S.concat $ L.toChunks lbs
-                            case compare (S.length bs) size of
+                            let bs' = S.concat $ L.toChunks lbs
+                            case compare (S.length bs') size of
                                 LT -> do
-                                    leftover bs
+                                    leftover bs'
                                     failure
-                                EQ -> process bs
-                                GT -> assert False (process bs)
+                                EQ -> process bs'
+                                GT -> assert False (process bs')
                         EQ -> process bs
                         GT -> do
                             let (x, y) = S.splitAt size bs
@@ -601,7 +413,7 @@ sinkStorableHelper wrap failure = do
                             process x
 
     -- Given a bytestring of exactly the correct size, grab the value
-    process bs = return $! wrap $! inlinePerformIO $!
+    process bs = return $! wrap $! accursedUnutterablePerformIO $!
         unsafeUseAsCString bs (safePeek undefined . castPtr)
 
     safePeek :: a -> Ptr a -> IO a
@@ -615,74 +427,3 @@ sinkStorableHelper wrap failure = do
 data SinkStorableException = SinkStorableInsufficientBytes
     deriving (Show, Typeable)
 instance Exception SinkStorableException
-
--- | Like 'IO.withBinaryFile', but provides a source to read bytes from.
---
--- @since 1.2.1
-withSourceFile
-  :: (MonadUnliftIO m, MonadIO n)
-  => FilePath
-  -> (ConduitM i ByteString n () -> m a)
-  -> m a
-withSourceFile fp inner =
-  withRunInIO $ \run ->
-  IO.withBinaryFile fp IO.ReadMode $
-  run . inner . sourceHandle
-
--- | Like 'IO.withBinaryFile', but provides a sink to write bytes to.
---
--- @since 1.2.1
-withSinkFile
-  :: (MonadUnliftIO m, MonadIO n)
-  => FilePath
-  -> (ConduitM ByteString o n () -> m a)
-  -> m a
-withSinkFile fp inner =
-  withRunInIO $ \run ->
-  IO.withBinaryFile fp IO.ReadMode $
-  run . inner . sinkHandle
-
--- | Same as 'withSinkFile', but lets you use a 'BB.Builder'.
---
--- @since 1.2.1
-withSinkFileBuilder
-  :: (MonadUnliftIO m, MonadIO n)
-  => FilePath
-  -> (ConduitM BB.Builder o n () -> m a)
-  -> m a
-withSinkFileBuilder fp inner =
-  withRunInIO $ \run ->
-  IO.withBinaryFile fp IO.ReadMode $ \h ->
-  run $ inner $ CL.mapM_ (liftIO . BB.hPutBuilder h)
-
--- | Like 'sinkFileCautious', but uses the @with@ pattern instead of
--- @MonadResource@.
---
--- @since 1.2.2
-withSinkFileCautious
-  :: (MonadUnliftIO m, MonadIO n)
-  => FilePath
-  -> (ConduitM S.ByteString o n () -> m a)
-  -> m a
-withSinkFileCautious fp inner =
-  withRunInIO $ \run -> bracket
-    (cautiousAcquire fp)
-    cautiousCleanup
-    (\(tmpFP, h) -> do
-        a <- run $ inner $ sinkHandle h
-        hClose h
-        renameFile tmpFP fp
-        return a)
-
--- | Helper function for Cautious functions above, do not export!
-cautiousAcquire :: FilePath -> IO (FilePath, IO.Handle)
-cautiousAcquire fp = openBinaryTempFile (takeDirectory fp) (takeFileName fp <.> "tmp")
-
--- | Helper function for Cautious functions above, do not export!
-cautiousCleanup :: (FilePath, IO.Handle) -> IO ()
-cautiousCleanup (tmpFP, h) = do
-  hClose h
-  removeFile tmpFP `Control.Exception.catch` \e ->
-    if isDoesNotExistError e
-      then return ()
-      else throwIO e

--- a/website/index.html
+++ b/website/index.html
@@ -114,85 +114,85 @@ Program:Google Chrome |  3d15h24m00s |      21.60
             </section>
 
             <section id="install">
-                <h2>Install arbtt</h2>
-                <ul class="installation">
-                  <h3>Binary installations</h3>
-                    <li>
-                        <b>Debian/Ubuntu:</b>
-                        <p>arbtt is available both in
-                        <a href="http://packages.debian.org/sid/arbtt">Debian's</a> and
-                        <a href="http://packages.ubuntu.com/raring/arbtt">Ubuntu's</a> repositories.</p>
-                        <p>Install arbtt:</p>
-                        <code class="command">sudo apt-get install arbtt</code>
-                        <p>Set it up to start automatically on system startup:</p>
-                        <code class="command">cp /usr/share/doc/arbtt/examples/arbtt-capture.desktop ~/.config/autostart/</code>
-                        <p>Start the daemon manually, if you want it to start capturing immediately,
-                        rather than at the next system restart:</p>
-                        <code class="command">(arbtt-capture &amp;)</code>
-                        <p>Create a minimal categorize.cfg file to allow arbtt-stats to be invoked without errors:</p>
-                        <code class="command">echo "{\$idle &gt; 60 ==&gt; tag inactive}" &gt; ~/.arbtt/categorize.cfg</code>
-                    </li>
-                    <li>
-                        <b>Windows:</b><br>Download the
-                        latest <a href="http://www.joachim-breitner.de/archive/arbtt/">arbtt-setup.exe</a>
-                        and follow the setup process as usual. This will set up the capturing daemon,
-                        but note that there is no graphical interface. Extracting stats from the data
-                        requires running arbtt-stats on the command line. Run
-                        <code>arbtt-stats --help</code> for a quick reference;
-                        for more detailed information, consult the
-                        <a href="doc/users_guide/arbtt-stats.html">manual</a>.
-                    </li>
-                    <h3>Source installations</h3>
+              <h2>Install arbtt</h2>
+              <h3>Binary installations</h3>
+              <ul class="installation">
+                <li>
+                  <b>Debian/Ubuntu:</b>
+                  <p>arbtt is available both in
+                  <a href="http://packages.debian.org/sid/arbtt">Debian's</a> and
+                  <a href="http://packages.ubuntu.com/raring/arbtt">Ubuntu's</a> repositories.</p>
+                  <p>Install arbtt:</p>
+                  <code class="command">sudo apt-get install arbtt</code>
+                  <p>Set it up to start automatically on system startup:</p>
+                  <code class="command">cp /usr/share/doc/arbtt/examples/arbtt-capture.desktop ~/.config/autostart/</code>
+                  <p>Start the daemon manually, if you want it to start capturing immediately,
+                  rather than at the next system restart:</p>
+                  <code class="command">(arbtt-capture &amp;)</code>
+                  <p>Create a minimal categorize.cfg file to allow arbtt-stats to be invoked without errors:</p>
+                  <code class="command">echo "{\$idle &gt; 60 ==&gt; tag inactive}" &gt; ~/.arbtt/categorize.cfg</code>
+                </li>
+                <li>
+                  <b>NixOS:</b>
+                  <p>
+                    arbtt can be enabled in your NixOS configuration via <code>services.arbtt.enable</code>, see
+		    <a href="https://github.com/NixOS/nixpkgs/blob/release-21.05/nixos/modules/services/monitoring/arbtt.nix">the NixOS module for more configuration settings</a>.
+	          </p>
+	        </li>
+                <li>
+                  <b>Windows:</b><br>Download the
+                  latest <a href="http://www.joachim-breitner.de/archive/arbtt/">arbtt-setup.exe</a>
+                  and follow the setup process as usual. This will set up the capturing daemon,
+                  but note that there is no graphical interface. Extracting stats from the data
+                  requires running arbtt-stats on the command line. Run
+                  <code>arbtt-stats --help</code> for a quick reference;
+                  for more detailed information, consult the
+                  <a href="doc/users_guide/arbtt-stats.html">manual</a>.
+                </li>
+	      </ul>
 
-                      <p>arbtt can be installed from source either via cabal install or from the source repository.</p>
-                      <b>Dependencies:</b>
-                      <p>arbtt depends on several libraries whose development versions (name often suffixed <code>-dev</code>) must be available or the compilation
-                        may fail with errors such as <code>X11-1.6.1.2 failed during the configure step</code>;
-                        these libraries include:
-                        <ul>
-                          <li>X11, for the X11 Haskell binding (possibly named <code>libx11-dev</code> or <code>xorg-dev</code> in your package manager)</li>
-                          <li>PCRE3, for pcre-light (possibly <code>libpcre3-dev</code>)</li>
-                          <li>XSS, for arbtt (possibly <code>libxss-dev</code>)</li>
-                        </ul>
-                      </p>
-                    <li>
-                      <b>From Hackage:</b>
-                      <p>arbtt has been <a href="http://hackage.haskell.org/package/arbtt">published on hackage</a>,
-                        the Haskell package database. If you have
-                        <a href="http://www.haskell.org/haskellwiki/Cabal-Install">cabal-install</a>
-                        available, you can install arbtt by simply running:</p>
-                        <code class="command">cabal install arbtt</code>
-                    </li>
+              <h3>Source installations</h3>
 
-                    <li>
-                        <b>Build from repo:</b>
-                        <p>Download the latest release from <a href="http://www.joachim-breitner.de/archive/arbtt/">the archive</a>.
-                        Extract the tarball and run the following commands to build and install the arbtt binaries:</p>
-                        <code class="command">runhaskell Setup.hs configure</code><br>
-                        <code class="command">runhaskell Setup.hs build</code><br>
-                        <code class="command">runhaskell Setup.hs install</code><br>
-                        <p>If you use GNOME or KDE, you can copy the file "arbtt-capture.desktop"
-                        to ~/.config/autostart/. If you didn't do a system-wide installation,
-                        you'll probably need to put the full path to arbtt-capture
-                        in the Exec line of the .desktop file.</p>
-                    </li>
-
-                    <li>
-                        <b>Mac OS X support:</b>
-                        <p>arbtt can run on Mac OS X systems. To compile it, you need to install the pkgconfig and pcre source packages
-                        using <a href="http://brew.sh">Homebrew</a> or <a href="https://www.macports.org">MacPorts</a>. For Homebrew, you can execute:</p>
-                        <code class="command">brew install pkgconfig</code><br>
-                        <code class="command">brew install pcre</code><br>
-                        <p>or for MacPorts:</p>
-                        <code class="command">sudo port install pkgconfig</code><br>
-                        <code class="command">sudo port install pcre</code><br>
-                        <p>Then, you can compile arbtt using the usual cabal commands.</p>
-                        <p>If you use MacPorts and have a linking error, it may be because of a conflict between the system libiconv and the MacPorts libiconv.
-                        Execute the following cabal command to resolve the conflict:</p>
-                        <code class="command">cabal configure --extra-lib-dir=/usr/lib</code><br>
-                        <p>When the installation is done, your arbtt binaries will be located in <code>~/Library/Haskell/bin</code> or <code>~/.cabal/bin</code>.</p>
-                    </li>
+              <p>arbtt depends on several libraries whose development versions (name often suffixed <code>-dev</code>) must be available or the compilation
+                may fail with errors such as <code>X11-1.6.1.2 failed during the configure step</code>;
+                these libraries include:
+                <ul>
+                  <li>X11, for the X11 Haskell binding (possibly named <code>libx11-dev</code> or <code>xorg-dev</code> in your package manager)</li>
+                  <li>PCRE3, for pcre-light (possibly <code>libpcre3-dev</code>)</li>
+                  <li>XSS, for arbtt (possibly <code>libxss-dev</code>)</li>
                 </ul>
+              </p>
+
+              <p>Fetch the latest revision using</p>
+              <code class="command">git glone https://github.com/nomeata/arbtt</code><br>
+              <p>and run the following command to build the arbtt binaries:</p>
+              <code class="command">cabal install --installdir=bin --install-method=copy --overwrite-policy=always</code><br>
+              <p>You will now find the binaries in the <code>bin</code>
+              subdirectory, which you can copy, for example, to
+              <code>/usr/local/bin</code>.</p>
+
+              <p>If you use GNOME or KDE, you can copy the file "arbtt-capture.desktop"
+              to <code>~/.config/autostart/</code>. If you didn't do a system-wide installation,
+              you'll probably need to put the full path to arbtt-capture
+              in the Exec line of the .desktop file.</p>
+
+              <h3>Mac OS X installation</h3>
+
+              <p>
+	        arbtt can run on Mac OS X systems. To compile it, you need to install the pkgconfig and pcre source packages
+                using <a href="http://brew.sh">Homebrew</a> or <a href="https://www.macports.org">MacPorts</a>. For Homebrew, you can execute:
+	      </p>
+              <code class="command">brew install pkgconfig</code><br>
+              <code class="command">brew install pcre</code><br>
+              <p>or for MacPorts:</p>
+              <code class="command">sudo port install pkgconfig</code><br>
+              <code class="command">sudo port install pcre</code><br>
+              <p>Then, you can compile arbtt using the usual cabal command, as described above.</p>
+              <p>
+	        If you use MacPorts and have a linking error, it may be because of a conflict between the system libiconv and the MacPorts libiconv.
+                Execute the following cabal command to resolve the conflict:
+	      </p>
+              <code class="command">cabal configure --extra-lib-dir=/usr/lib</code><br>
             </section>
 
             <section id="contact">


### PR DESCRIPTION
by updating the convenience copy of `arbtt-extra` files. Fixes #136.