### PR TITLE
relax dependency on tasty-golden

### DIFF
--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -289,7 +289,7 @@ test-suite test
   Build-depends:
       base >= 4.7 && < 5
       , tasty >= 0.7 && < 1.5
-      , tasty-golden >= 2.2.0.2  && <= 2.3.4
+      , tasty-golden >= 2.2.0.2  && < 2.4
       , tasty-hunit >= 0.2  && < 0.11
       , process-extras >= 0.2 && < 0.8
       , deepseq


### PR DESCRIPTION
It appears that the arbtt tests are able to successfully run against the latest version of tasty-golden (2.3.5).

This relaxes the version bounds on tasty-golden to allow 2.3.5 in the cabal file.

We noticed this in Nixpkgs:

- https://hydra.nixos.org/build/164948454
- https://hydra.nixos.org/build/164948454/nixlog/1