### PR TITLE
arbtt-dump: Add --first

### DIFF
--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -153,7 +153,6 @@ executable arbtt-dump
         parsec == 3.*,
         containers >= 0.5 && < 0.7,
         aeson >= 0.10  && < 2.1,
-        array == 0.4.* || == 0.5.*,
         binary >= 0.5,
         deepseq, bytestring, utf8-string, strict,
         transformers, directory, filepath

--- a/src/Data/List/TakeR.hs
+++ b/src/Data/List/TakeR.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Data.List.TakeR where
 
-import Control.Monad.ST
-import Debug.Trace
-import Data.Array.MArray
-import Data.Array.ST
-
 -- Efficient taking of last r values
+takeR :: Int -> [a] -> [a]
 takeR n l = go (drop n l) l
   where
     go [] r = r
@@ -14,6 +10,11 @@ takeR n l = go (drop n l) l
 
 -- Much faster and better evaluation properties than:
 {-
+import Control.Monad.ST
+import Debug.Trace
+import Data.Array.MArray
+import Data.Array.ST
+
 takeR :: forall a. Int -> [a] -> [a]
 takeR n l | n <= 0 = []
 takeR n l = runST stAction

--- a/src/dump-main.hs
+++ b/src/dump-main.hs
@@ -72,7 +72,7 @@ options =
                         hPutStrLn stderr ("Invalid number \"" ++ arg ++ "\".")
                         hPutStr stderr (usageInfo header options)
                         exitFailure) "NUMBER")
-               "only dump the last NUMBER of samples."
+               "only dump the first NUMBER of samples."
      , Option "l"      ["last"]
               (ReqArg (\arg opt ->
                 case reads arg of

--- a/src/dump-main.hs
+++ b/src/dump-main.hs
@@ -23,12 +23,14 @@ import Paths_arbtt (version)
 data Options = Options
     { optLogFile :: String
     , optFormat :: DumpFormat
+    , optFirst :: Maybe Int
     , optLast :: Maybe Int
     }
 
 defaultOptions dir = Options
     { optLogFile = dir </> "capture.log"
     , optFormat = DFHuman
+    , optFirst = Nothing
     , optLast = Nothing
     }
 
@@ -62,6 +64,15 @@ options =
                         hPutStr stderr (usageInfo header options)
                         exitFailure) "FORMAT")
                "output format, one of Human (default), Show or JSON "
+     , Option "i"      ["first"]
+              (ReqArg (\arg opt ->
+                case reads arg of
+                    [(n, "")] | n >= 0 -> return $ opt { optFirst = Just n }
+                    _                  -> do
+                        hPutStrLn stderr ("Invalid number \"" ++ arg ++ "\".")
+                        hPutStr stderr (usageInfo header options)
+                        exitFailure) "NUMBER")
+               "only dump the last NUMBER of samples."
      , Option "l"      ["last"]
               (ReqArg (\arg opt ->
                 case reads arg of
@@ -84,11 +95,16 @@ main = do
 
   dir <- getAppUserDataDirectory "arbtt"
   flags <- foldl (>>=) (return (defaultOptions dir)) actions
-  
+
   captures <- readTimeLog (optLogFile flags) :: IO (TimeLog CaptureData)
 
-  captures <- case optLast flags of 
-    Nothing -> return captures
-    Just n  -> return $ takeR n captures
+  captures <- case (optFirst flags, optLast flags) of
+    (Nothing, Nothing) -> return captures
+    (Just n , Nothing) -> return $ take n captures
+    (Nothing, Just n ) -> return $ takeR n captures
+    (Just _ , Just _ ) -> do
+        hPutStrLn stderr "--first and --last are mutually exclusive"
+        hPutStr stderr (usageInfo header options)
+        exitFailure
 
   dumpSamples (optFormat flags) captures


### PR DESCRIPTION
There already is --last, but this one was missing. Can be useful in a script deciding whether to rotate the log file or not.

(I couldn't decide between `take i ∘ takeR l` and `takeR l ∘ take i` so these options are mutually exclusive.)