### PR TITLE
Migrate from deprecated runGetState to runGetOrFail; Fix parsing of empty logfiles

### DIFF
--- a/arbtt.cabal
+++ b/arbtt.cabal
@@ -44,7 +44,7 @@ executable arbtt-capture
                 filepath, directory, transformers, utf8-string, strict,
                 containers >= 0.5 && < 0.7,
                 aeson >= 0.10  && < 2.1,
-                binary >= 0.5,
+                binary >= 0.6.4,
                 bytestring, deepseq
 
     if flag(old-locale)
@@ -104,7 +104,7 @@ executable arbtt-stats
         parsec == 3.*,
         containers >= 0.5 && < 0.7,
         pcre-light,
-        binary >= 0.5,
+        binary >= 0.6.4,
         deepseq, bytestring, utf8-string, strict,
         transformers, directory, filepath,
         aeson >= 0.10  && < 2.1,
@@ -153,7 +153,7 @@ executable arbtt-dump
         parsec == 3.*,
         containers >= 0.5 && < 0.7,
         aeson >= 0.10  && < 2.1,
-        binary >= 0.5,
+        binary >= 0.6.4,
         deepseq, bytestring, utf8-string, strict,
         transformers, directory, filepath
 
@@ -189,7 +189,7 @@ executable arbtt-import
         base >= 4.7 && < 5,
         parsec == 3.*,
         containers >= 0.5 && < 0.7,
-        binary >= 0.5,
+        binary >= 0.6.4,
         aeson >= 0.10  && < 2.1,
         conduit >= 1.2 && < 1.4,
         exceptions >= 0.8,
@@ -242,7 +242,7 @@ executable arbtt-recover
     build-depends:
         base >= 4.7 && < 5,
         containers >= 0.5 && < 0.7,
-        binary >= 0.5,
+        binary >= 0.6.4,
         deepseq, bytestring, utf8-string,
         directory, filepath
 
@@ -292,7 +292,7 @@ test-suite test
       , tasty-hunit >= 0.2  && < 0.11
       , process-extras >= 0.2 && < 0.8
       , deepseq
-      , binary >= 0.5
+      , binary >= 0.6.4
       , bytestring
       , utf8-string
       , directory

--- a/src/Data.hs
+++ b/src/Data.hs
@@ -93,7 +93,7 @@ instance StringReferencingBinary a => StringReferencingBinary (TimeLogEntry a) w
         v <- getWord8
         case v of
          1 -> TimeLogEntry <$> get <*> get <*> ls_get strs
-         _ -> error $ "Unsupported TimeLogEntry version tag " ++ show v ++ "\n" ++
+         _ -> fail $ "Unsupported TimeLogEntry version tag " ++ show v ++ "\n" ++
                       "You can try to recover your data using arbtt-recover."
 
 instance Binary UTCTime where
@@ -131,7 +131,7 @@ instance StringReferencingBinary CaptureData where
          2 -> CaptureData <$> (map fromWDv0 . fromIntLenW <$> ls_get strs) <*> ls_get strs <*> pure ""
          3 -> CaptureData <$> (map fromWDv0 . fromIntLenW <$> ls_get strs) <*> ls_get strs <*> (fromIntLen <$> ls_get strs)
          4 -> CaptureData <$> ls_get strs <*> ls_get strs <*> ls_get strs
-         _ -> error $ "Unsupported CaptureData version tag " ++ show v ++ "\n" ++
+         _ -> fail $ "Unsupported CaptureData version tag " ++ show v ++ "\n" ++
                       "You can try to recover your data using arbtt-recover."
 
 fromIntLenW :: IntLen [(Bool, IntLen Text, IntLen Text)] -> [(Bool, Text, Text)]
@@ -164,5 +164,5 @@ instance StringReferencingBinary WindowData where
              wProgram <- ls_get strs
              wDesktop <- ls_get strs
              return WindowData{..}
-         _ -> error $ "Unsupported WindowData version tag " ++ show v ++ "\n" ++
+         _ -> fail $ "Unsupported WindowData version tag " ++ show v ++ "\n" ++
                       "You can try to recover your data using arbtt-recover."

--- a/src/Data/Binary/StringRef.hs
+++ b/src/Data/Binary/StringRef.hs
@@ -70,7 +70,9 @@ instance StringReferencingBinary Text where
                 _ ->    putWord8 0 >> ls_put strs (T.unpack s)
         ls_get strs = getWord8 >>= \case
                 0 -> T.pack <$> ls_get strs
-                i -> return $! strs !! fromIntegral (pred i)
+                i -> case drop (fromIntegral (pred i)) strs of
+                    [] -> fail "invalid string reference"
+                    s : _ -> return s
 
 -- | 'ls_get strsMany n' ls_get strs 'n' elements in order, without blowing the stack.
 ls_getMany :: StringReferencingBinary a => [Text] -> Int -> Get [a]
@@ -105,7 +107,9 @@ instance StringReferencingBinary (IntLen Text) where
                 _ ->    putWord8 0 >> ls_put strs (IntLen (T.unpack s))
         ls_get strs = fmap IntLen $ getWord8 >>= \case
                 0 -> T.pack . fromIntLen <$> ls_get strs
-                i -> return $! strs !! fromIntegral (pred i)
+                i -> case drop (fromIntegral (pred i)) strs of
+                    [] -> fail "invalid string reference"
+                    s : _ -> return s
 
 {-
 instance Binary a => StringReferencingBinary a where

--- a/src/TimeLog.hs
+++ b/src/TimeLog.hs
@@ -129,13 +129,12 @@ parseTimeLog input =
     (startString, rest, off) = case runGetOrFail (getLazyByteString (BS.length magic)) input of
         Right (rest, off, x) -> (x, rest, off)
         Left (_, off, e) -> error $ "Timelog parse error at " ++ show off ++ ": " ++ e
-    go prev input off = case runGetOrFail (ls_get strs) input of
-        Right (rest, off', v) ->
-            v `deepseq`
-            if (BS.null rest)
-            then [v]
-            else v : go (Just (tlData v)) rest (off + off')
-        Left (_, off', e) ->
-            error $ "Timelog parse error at " ++ show (off + off') ++ ": " ++ e
+    go prev input off
+        | BS.null input = []
+        | otherwise = case runGetOrFail (ls_get strs) input of
+            Right (rest, off', v) ->
+                v `deepseq` v : go (Just (tlData v)) rest (off + off')
+            Left (_, off', e) ->
+                error $ "Timelog parse error at " ++ show (off + off') ++ ": " ++ e
       where strs = maybe [] listOfStrings prev
 

--- a/src/stats-main.hs
+++ b/src/stats-main.hs
@@ -189,7 +189,7 @@ main = do
       let pbStyle = defStyle { stylePrefix = msg (TL.pack "Processing data")
                              , stylePostfix = percentage }
       pb <- hNewProgressBar stderr pbStyle 10 (Progress 0 100 ())
-      trackProgressWithChunkSize (fromIntegral size `div` 100)
+      trackProgressWithChunkSize (1 `max` (fromIntegral size `div` 100))
           (\_ b -> updateProgress pb (const (Progress (fromIntegral b) (fromIntegral size) ())))
           timelog
     False -> return timelog

--- a/tests/empty.log
+++ b/tests/empty.log
@@ -1,0 +1,1 @@
+arbtt-timelog-v1

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -117,6 +117,9 @@ goldenTests = testGroup "Golden tests"
     , goldenVsString "stats small_v4 ($hidden, $wdesktop)"
         "tests/small_v4_stats.out" $
         run "arbtt-stats" ["--logfile", "tests/small_v4.log", "--categorize", "tests/small_v4.cfg"] B.empty
+    , goldenVsString "dump empty"
+        "tests/empty_dump.out" $
+        run "arbtt-dump" ["-f","tests/empty.log", "-t", "Show"] B.empty
     ]
 
 testParser env parser input = do


### PR DESCRIPTION
#### [Migrate from deprecated runGetState to runGetOrFail](../commit/88310d61ac6efd6187317b2485a43c07008e99bc)

runGetState has been deprecated since binary-0.6.0.0 (2012).

This also happens to fix error positions as runGetState ignores the off
parameter when reporting errors. Given a logfile with just the header
but no entries, the old code reports:

    arbtt-dump: Data.Binary.Get.runGetState at position 0: not enough bytes
    CallStack (from HasCallStack):
      error, called at libraries/binary/src/Data/Binary/Get.hs:312:5 in binary-0.8.7.0:Data.Binary.Get

The new correctly reports:

    arbtt-dump: Timelog parse error at 17: not enough bytes
    CallStack (from HasCallStack):
      error, called at src/TimeLog.hs:150:13 in main:TimeLog

#### [Fix parsing of empty logfiles](../commit/25032fdac703965244cbc2212346e6008fbb489d)

arbtt-import will happily create a logfile with just a header and no
entries, so arbtt-{dump,stats} shouldn't crash when parsing it.
